### PR TITLE
Add simple SOP web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# SOP Web App
+
+This lightweight Flask application lets you upload SOPs written in Markdown
+and walk through them step by step. Each step can be marked completed.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+Then open `http://localhost:5000` in your browser.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,59 @@
+from flask import Flask, render_template, request, redirect, url_for, session
+import markdown
+
+app = Flask(__name__)
+app.secret_key = 'change_this_secret'  # should be changed in production
+
+
+def parse_steps(md_text):
+    """Parse markdown text into a list of step strings."""
+    lines = md_text.splitlines()
+    steps = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith('- ') or line.startswith('* '):
+            step = line[2:].strip()
+            steps.append(step)
+        elif line[0].isdigit() and line[1:2] in {'.', ')'}:
+            step = line[2:].strip()
+            steps.append(step)
+    return steps
+
+
+@app.route('/', methods=['GET', 'POST'])
+def upload():
+    if request.method == 'POST':
+        file = request.files.get('file')
+        if file and file.filename:
+            content = file.read().decode('utf-8')
+            steps = parse_steps(content)
+            session['steps'] = [{'text': s, 'done': False} for s in steps]
+            session['original'] = content
+            return redirect(url_for('steps'))
+    return render_template('upload.html')
+
+
+@app.route('/steps', methods=['GET', 'POST'])
+def steps():
+    if 'steps' not in session:
+        return redirect(url_for('upload'))
+
+    if request.method == 'POST':
+        completed = request.form.getlist('step')
+        for i, step in enumerate(session['steps']):
+            step['done'] = str(i) in completed
+        session.modified = True
+    all_done = all(step["done"] for step in session["steps"])
+    return render_template("steps.html", steps=session["steps"], all_done=all_done)
+
+
+@app.route('/reset')
+def reset():
+    session.clear()
+    return redirect(url_for('upload'))
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+markdown

--- a/templates/steps.html
+++ b/templates/steps.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+<head>
+    <title>SOP Steps</title>
+</head>
+<body>
+    <h1>SOP Steps</h1>
+    {% if all_done %}
+    <p>All steps completed!</p>
+    {% endif %}
+    <form method="post">
+        <ul>
+        {% for step in steps %}
+            <li>
+                <label>
+                    <input type="checkbox" name="step" value="{{ loop.index0 }}" {% if step.done %}checked{% endif %}>
+                    {{ step.text }}
+                </label>
+            </li>
+        {% endfor %}
+        </ul>
+        <button type="submit">Update</button>
+    </form>
+    <a href="{{ url_for('reset') }}">Reset SOP</a>
+</body>
+</html>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+<head>
+    <title>Upload SOP</title>
+</head>
+<body>
+    <h1>Upload SOP Markdown</h1>
+    <form method="post" enctype="multipart/form-data">
+        <input type="file" name="file" accept=".md" required>
+        <button type="submit">Upload</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- set up minimal Flask app with session-based SOP progress tracking
- add HTML templates for uploading markdown SOPs and marking steps complete
- document setup in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6883ed05cac48324966144085c71b61f